### PR TITLE
Fix missing become statements

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -108,6 +108,7 @@
       copy:
         src: /mnt/opt/google/dsm/dsmparam.bin
         dest: /opt/google/dsm/dsmparam.bin
+      become: true
 
     - name: Copy firmware files
       copy:
@@ -160,6 +161,7 @@
         name: "{{ ansible_user_id }}"
         groups: input
         append: yes
+      become: true
 
     - name: Enable acpid
       systemd:


### PR DESCRIPTION
Thank you for your incredible work figuring out how to get everything working on the Pixelbook, creating an ansible playbook for it, and setting up this repository!

I noticed that a few of the ansible tasks failed because they need to be run as root. Adding these `become` statements fixed things for me.