### PR TITLE
Rewrite pixelbook-keyboard-backlight using only evdev for python 3.13

### DIFF
--- a/scripts/pixelbook-keyboard-backlight
+++ b/scripts/pixelbook-keyboard-backlight
@@ -1,41 +1,36 @@
 #!/usr/bin/python3
 
-import os
+import evdev
 
-if "DISPLAY" not in os.environ or os.environ["DISPLAY"] is None:
-  os._exit(0)
+def detect_key_combination():
+    devices = evdev.list_devices()
+    for device in devices:
+        if evdev.InputDevice(device).name == "AT Translated Set 2 keyboard":
+            keyboard = evdev.InputDevice(device)
+            break
 
-from pynput import keyboard
+    key_combo = [evdev.ecodes.KEY_LEFTCTRL, evdev.ecodes.KEY_SPACE]
+    file = "/sys/class/leds/chromeos::kbd_backlight/brightness"
+    keys_down = set()
 
-# The key combination to check
-COMBINATION = {keyboard.Key.ctrl, keyboard.Key.space}
+    for event in keyboard.read_loop():
+        if event.type == evdev.ecodes.EV_KEY:
+            if event.value == 1:
+                keys_down.add(event.code)
+            elif event.value == 0:
+                keys_down.discard(event.code)
 
-# The currently active modifiers
-current = set()
+            if keys_down == set(key_combo):
+                f = open(file, "w+")
+                cur = f.readline()
+                if cur == "0\n":
+                  f.write("50")
+                elif cur == "100\n":
+                  f.write("0")
+                else:
+                  f.write("100")
 
-file = "/sys/class/leds/chromeos::kbd_backlight/brightness"
+                f.close()
 
-def on_press(key):
-    if key in COMBINATION:
-        current.add(key)
-        if all(k in current for k in COMBINATION):
-            f = open(file, "w+")
-            cur = f.readline()
-            if cur == "0\n":
-              f.write("50")
-            elif cur == "100\n":
-              f.write("0")
-            else:
-              f.write("100")
-
-            f.close()
-
-def on_release(key):
-    try:
-        current.remove(key)
-    except KeyError:
-        pass
-
-
-with keyboard.Listener(on_press=on_press, on_release=on_release) as listener:
-    listener.join()
+if __name__ == "__main__":
+    detect_key_combination()

--- a/specs/pixelbook-scripts.spec
+++ b/specs/pixelbook-scripts.spec
@@ -1,5 +1,5 @@
 Name:       pixelbook-scripts
-Version:    1.0.8
+Version:    1.0.9
 Release:    1%{?dist}
 Summary:    Scripts for interacting with pixelbook backlights and touchpad
 License:    WTFPL
@@ -65,6 +65,9 @@ install -m 0644 %{SOURCE7} %{buildroot}%{_userunitdir}/
 /%{_userunitdir}/*
 
 %changelog
+* Tue Oct 16 2024 Jason Montleon <jmontleo@redhat.com> - 1.0.9-1
+- Rewrite pixelbook-keyboard-backlight using only evdev for python 3.13
+
 * Tue Aug 02 2022 Jason Montleon <jmontleo@redhat.com> - 1.0.8-1
 - Stop keyboard backlight service from failing
 


### PR DESCRIPTION
pynput is partially broken with python 3.13.